### PR TITLE
Fixes for Python 3.8

### DIFF
--- a/phomemo_m02s/_image_helper.py
+++ b/phomemo_m02s/_image_helper.py
@@ -6,6 +6,7 @@ import math
 
 import PIL
 import PIL.Image
+import PIL.ImageOps
 
 def preprocess_image(src, width=512, save=False):
     src_w, src_h = src.size

--- a/phomemo_m02s/printer.py
+++ b/phomemo_m02s/printer.py
@@ -2,6 +2,8 @@
 # Published under the standard MIT License.
 # Full text available at: https://opensource.org/licenses/MIT
 
+from __future__ import annotations
+
 import PIL
 import serial
 import socket


### PR DESCRIPTION
Hit a couple of issues with python 3.8 on Ubuntu 20.04. The `import PIL.ImageOps` should be good anywhere. I'm not familiar enough with python to know if the `__futures__` is the best fix or if it can be solved in a better way. 